### PR TITLE
Implement role based authorization

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -30,12 +30,18 @@ class Ability
     #
     # See the wiki for details:
     # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
-
     can :read, Discussion
     can :read, Comment
     can :read, Category
 
     return unless user.present?
+
+    if user.auth_role == "banned"
+      cannot :read, Discussion
+      cannot :read, Category
+      cannot :read, Comment
+      return 
+    end
 
     can :create, Discussion, user: user
     can :delete, Discussion, user: user

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -50,5 +50,16 @@ class Ability
     can :create, Comment, discussion: { locked: false }
     can :update, Comment, user: user
     can :delete, Comment, user: user
+
+    if user.auth_role == "admin"
+      can :update, Category
+      can :delete, Category
+      can :create, Discussion
+      can :delete, Discussion
+      can :update, Discussion
+      can :update, Comment
+      can :delete, Comment
+      can :create, Comment
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,14 @@
 class User < ApplicationRecord
+  ROLES = %w{admin moderator user banned}
+
   has_many :discussions, dependent: :destroy
   has_many :comments, dependent: :destroy
+
+  validates :auth_role, inclusion: { in: ROLES }
+
+  before_validation(on: :create) do 
+    self.auth_role ||= self.class.default_auth_role
+  end
 
   def self.create_with_omniauth(auth)
     create! do |user|
@@ -17,5 +25,9 @@ class User < ApplicationRecord
 
   def post_count
     comments.count + discussions.count 
+  end
+
+  def self.default_auth_role
+    "user"
   end
 end

--- a/db/migrate/20211019215116_add_role_to_user.rb
+++ b/db/migrate/20211019215116_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :auth_role, :string
+  end
+end

--- a/db/migrate/20211019224444_instanciate_initial_role_to_existing_users.rb
+++ b/db/migrate/20211019224444_instanciate_initial_role_to_existing_users.rb
@@ -1,0 +1,5 @@
+class InstanciateInitialRoleToExistingUsers < ActiveRecord::Migration[6.1]
+  def change
+    User.where(auth_role: nil).update_all(auth_role: User.default_auth_role)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_13_231400) do
+ActiveRecord::Schema.define(version: 2021_10_19_224444) do
 
   create_table "categories", force: :cascade do |t|
     t.string "name"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2021_10_13_231400) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "image"
+    t.string "auth_role"
   end
 
   add_foreign_key "comments", "discussions"

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -1,0 +1,29 @@
+namespace :admin do
+  desc "Set a user to admin. Note: this only works once"
+  task set: [:environment] do
+    if User.where(auth_role: "admin").count > 0
+      puts "User already exists with admin role! Have them help you!"
+      exit 1
+    end
+
+    login = ARGV[0]
+    unless login
+      puts "You must specify a login to set as admin!"
+      exit 1
+    end
+
+    user = User.find_by(login: login)
+    unless user
+      puts "User #{login} could not be found!"
+      exit 1
+    end
+
+    if user.update(auth_role: "admin")
+      puts "Successfully set #{login} to admin!"
+      exit 0
+    else
+      puts "User could not be made admin! Reason: #{user.errors.full_messages}"
+      exit 1
+    end
+  end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,1 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  login: MyString
-  provider: MyString
-  uid: 1
-
-two:
-  login: MyString
-  provider: MyString
-  uid: 1

--- a/test/models/abilities/admin_test.rb
+++ b/test/models/abilities/admin_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class Ability::AdminTest < ActiveSupport::TestCase
+  def setup
+    @category = Category.new
+    @user = User.new(auth_role: "admin")
+    @user_2 = User.new
+    @discussion = @category.discussions.build(user: @user)
+    @discussion2 = @category.discussions.build(user: @user_2)
+    @comment = @discussion.comments.build(user: @user, body: "This is a test")
+    @comment2 = @discussion2.comments.build(user: @user_2, body: "This is a test")
+  end
+
+  test "can read all Category" do
+    assert Ability.new(@user).can?(:read, @category)
+  end
+
+  test "can update a Category" do
+    assert Ability.new(@user).can?(:update, @category)
+  end
+
+  test "can delete a Category" do
+    assert Ability.new(@user).can?(:delete, @category)
+  end
+
+  test "can read all Discussions" do
+    assert Ability.new(@user).can?(:read, @discussion)
+  end
+
+  test "can create a Discussion made by someone else" do
+    assert Ability.new(@user).can?(:create, @discussion2)
+  end
+
+  test "can create a Discussion made by themselves" do
+    assert Ability.new(@user).can?(:create, @discussion)
+  end
+
+  test "can delete their own Discussion" do
+    assert Ability.new(@user).can?(:delete, @discussion)
+  end
+
+  test "can delete a Discussion made by someone else" do
+    assert Ability.new(@user).can?(:delete, @discussion2)
+  end
+
+  test "can update their own Discussion" do
+    assert Ability.new(@user).can?(:update, @discussion)
+  end
+
+  test "can update a Discussion made by someone else" do
+    assert Ability.new(@user).can?(:update, @discussion2)
+  end
+
+  test "can update their own Comment" do
+    assert Ability.new(@user).can?(:update, @comment)
+  end
+
+  test "can update a Comment made by someone else" do
+    assert Ability.new(@user).can?(:update, @comment2)
+  end
+
+  test "can read all Comments" do
+    assert Ability.new(@user).can?(:read, @comment)
+  end
+
+  test "can create a Comment" do
+    assert Ability.new(@user).can?(:create, @comment)
+  end
+
+  test "can create a Comment on a locked discussion" do
+    @discussion.locked = true
+
+    assert Ability.new(@user).can?(:create, @comment)
+  end
+
+  test "can delete a Comment" do
+    assert Ability.new(@user).can?(:delete, @comment)
+  end
+
+  test "can delete a Comment made by someone else" do
+    assert Ability.new(@user).can?(:delete, @comment2)
+  end
+end

--- a/test/models/abilities/authenticated_user_test.rb
+++ b/test/models/abilities/authenticated_user_test.rb
@@ -12,6 +12,14 @@ class Ability::AuthenticatedUserTest < ActiveSupport::TestCase
     assert Ability.new(@user).can?(:read, @category)
   end
 
+  test "cannot update a Category" do
+    refute Ability.new(@user).can?(:update, @category)
+  end
+
+  test "cannot delete a Category" do
+    refute Ability.new(@user).can?(:delete, @category)
+  end
+
   test "can read all Discussions" do
     assert Ability.new(@user).can?(:read, @discussion)
   end

--- a/test/models/abilities/authenticated_user_test.rb
+++ b/test/models/abilities/authenticated_user_test.rb
@@ -1,73 +1,72 @@
 require "test_helper"
 
-class AbilityTest < ActiveSupport::TestCase
+class Ability::AuthenticatedUserTest < ActiveSupport::TestCase
   def setup
     @category = Category.new
     @user = User.new
-    @user_2 = User.new
     @discussion = @category.discussions.build(user: @user)
     @comment = @discussion.comments.build(user: @user, body: "This is a test")
   end
 
-  test "authenticated user can read all Category" do
+  test "can read all Category" do
     assert Ability.new(@user).can?(:read, @category)
   end
 
-  test "authenticated user can read all Discussions" do
+  test "can read all Discussions" do
     assert Ability.new(@user).can?(:read, @discussion)
   end
 
-  test "authenticated user cannot create a Discussion made by someone else" do
+  test "cannot create a Discussion made by someone else" do
     refute Ability.new(@user_2).can?(:create, @discussion)
   end
 
-  test "authenticated user can create a Discussion made by themselves" do
+  test "can create a Discussion made by themselves" do
     assert Ability.new(@user).can?(:create, @discussion)
   end
 
-  test "authenticated user can delete their own Discussion" do
+  test "can delete their own Discussion" do
     assert Ability.new(@user).can?(:delete, @discussion)
   end
 
-  test "authenticated user cannot delete a Discussion made by someone else" do
+  test "cannot delete a Discussion made by someone else" do
     refute Ability.new(@user_2).can?(:delete, @discussion)
   end
 
-  test "authenticated user can update their own Discussion" do
+  test "can update their own Discussion" do
     assert Ability.new(@user).can?(:update, @discussion)
   end
 
-  test "authenticated user cannot update a Discussion made by someone else" do
+  test "cannot update a Discussion made by someone else" do
     refute Ability.new(@user_2).can?(:update, @discussion)
   end
 
-  test "authenticated user can update their own Comment" do
+  test "can update their own Comment" do
     assert Ability.new(@user).can?(:update, @comment)
   end
 
-  test "authenticated user cannot update a Comment made by someone else" do
+  test "cannot update a Comment made by someone else" do
     refute Ability.new(@user_2).can?(:update, @comment)
   end
 
-  test "authenticated user can read all Comments" do
+  test "can read all Comments" do
     assert Ability.new(@user).can?(:read, @comment)
   end
 
-  test "authenticated user can create a Comment" do
+  test "can create a Comment" do
     assert Ability.new(@user).can?(:create, @comment)
   end
 
-  test "authenticated user cannot create a Comment on a locked discussion" do
+  test "cannot create a Comment on a locked discussion" do
     @discussion.locked = true
 
     refute Ability.new(@user).can?(:create, @comment)
   end
 
-  test "authenticated user can delete a Comment" do
+  test "can delete a Comment" do
     assert Ability.new(@user).can?(:delete, @comment)
   end
 
-  test "authenticated user cannot delete a Comment made by someone else" do
+  test "cannot delete a Comment made by someone else" do
     refute Ability.new(@user_2).can?(:delete, @comment)
   end
 end

--- a/test/models/abilities/banned_test.rb
+++ b/test/models/abilities/banned_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class Ability::BannedTest < ActiveSupport::TestCase
+  def setup
+    @category = Category.new
+    @user = User.new(auth_role: "banned")
+    @discussion = @category.discussions.build(user: @user)
+    @comment = @discussion.comments.build(user: @user, body: "This is a test")
+  end
+
+  test "cannot read a category" do
+    refute Ability.new(@user).can?(:read, @category)
+  end
+
+  test "cannot create a category" do
+    refute Ability.new(@user).can?(:create, @category)
+  end
+
+  test "cannot update a category" do
+    refute Ability.new(@user).can?(:update, @category)
+  end
+
+  test "cannot destroy a category" do
+    refute Ability.new(@user).can?(:destroy, @category)
+  end
+
+  test "cannot read a discussion" do
+    refute Ability.new(@user).can?(:read, @discussion)
+  end
+
+  test "cannot create a discussion" do
+    refute Ability.new(@user).can?(:create, @discussion)
+  end
+
+  test "cannot update a discussion" do
+    refute Ability.new(@user).can?(:update, @discussion)
+  end
+
+  test "cannot destroy a discussion" do
+    refute Ability.new(@user).can?(:destroy, @discussion)
+  end
+
+  test "cannot read a comment" do
+    refute Ability.new(@user).can?(:read, @comment)
+  end
+
+  test "cannot create a comment" do
+    refute Ability.new(@user).can?(:create, @comment)
+  end
+
+  test "cannot update a comment" do
+    refute Ability.new(@user).can?(:update, @comment)
+  end
+
+  test "cannot destroy a comment" do
+    refute Ability.new(@user).can?(:destroy, @comment)
+  end
+end

--- a/test/models/abilities/guest_test.rb
+++ b/test/models/abilities/guest_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class Ability::GuestTest < ActiveSupport::TestCase
+  def setup
+    @category = Category.new
+    @user = User.new
+    @user_2 = nil
+    @discussion = @category.discussions.build(user: @user)
+    @comment = @discussion.comments.build(user: @user, body: "This is a test")
+  end
+
+  test "can read all Category" do
+    assert Ability.new(@user_2).can?(:read, @category)
+  end
+
+  test "can read all Discussions" do
+    assert Ability.new(nil).can?(:read, @discussion)
+  end
+
+  test "cannot create a Discussion" do
+    refute Ability.new(nil).can?(:create, @discussion)
+  end
+
+  test "cannot delete a Discussion made by someone else" do
+    refute Ability.new(nil).can?(:delete, @discussion)
+  end
+
+  test "cannot update a Discussion" do
+    refute Ability.new(nil).can?(:update, @discussion)
+  end
+
+  test "cannot update a Comment" do
+    refute Ability.new(nil).can?(:update, @comment)
+  end
+
+  test "can read all Comments" do
+    assert Ability.new(nil).can?(:read, @comment)
+  end
+
+  test "cannot create a Comment" do
+    refute Ability.new(nil).can?(:create, @comment)
+  end
+
+  test "cannot delete a Comment" do
+    refute Ability.new(nil).can?(:delete, @comment)
+  end
+end

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -13,10 +13,6 @@ class AbilityTest < ActiveSupport::TestCase
     assert Ability.new(@user).can?(:read, @category)
   end
 
-  test "unauthenticated guest can read all Category" do
-    assert Ability.new(nil).can?(:read, @category)
-  end
-
   test "authenticated user can read all Discussions" do
     assert Ability.new(@user).can?(:read, @discussion)
   end
@@ -29,14 +25,6 @@ class AbilityTest < ActiveSupport::TestCase
     assert Ability.new(@user).can?(:create, @discussion)
   end
 
-  test "unauthenticated guest can read all Discussions" do
-    assert Ability.new(nil).can?(:read, @discussion)
-  end
-
-  test "unauthenticated guest cannot create a Discussion" do
-    refute Ability.new(nil).can?(:create, @discussion)
-  end
-
   test "authenticated user can delete their own Discussion" do
     assert Ability.new(@user).can?(:delete, @discussion)
   end
@@ -45,16 +33,8 @@ class AbilityTest < ActiveSupport::TestCase
     refute Ability.new(@user_2).can?(:delete, @discussion)
   end
 
-  test "unauthenticated guest cannot delete a Discussion made by someone else" do
-    refute Ability.new(nil).can?(:delete, @discussion)
-  end
-
   test "authenticated user can update their own Discussion" do
     assert Ability.new(@user).can?(:update, @discussion)
-  end
-
-  test "unauthenticated guest cannot update a Discussion" do
-    refute Ability.new(nil).can?(:update, @discussion)
   end
 
   test "authenticated user cannot update a Discussion made by someone else" do
@@ -65,10 +45,6 @@ class AbilityTest < ActiveSupport::TestCase
     assert Ability.new(@user).can?(:update, @comment)
   end
 
-  test "unauthenticated guest cannot update a Comment" do
-    refute Ability.new(nil).can?(:update, @comment)
-  end
-
   test "authenticated user cannot update a Comment made by someone else" do
     refute Ability.new(@user_2).can?(:update, @comment)
   end
@@ -77,16 +53,8 @@ class AbilityTest < ActiveSupport::TestCase
     assert Ability.new(@user).can?(:read, @comment)
   end
 
-  test "unauthenticated guest can read all Comments" do
-    assert Ability.new(nil).can?(:read, @comment)
-  end
-
   test "authenticated user can create a Comment" do
     assert Ability.new(@user).can?(:create, @comment)
-  end
-
-  test "unauthenticated guest cannot create a Comment" do
-    refute Ability.new(nil).can?(:create, @comment)
   end
 
   test "authenticated user cannot create a Comment on a locked discussion" do
@@ -101,9 +69,5 @@ class AbilityTest < ActiveSupport::TestCase
 
   test "authenticated user cannot delete a Comment made by someone else" do
     refute Ability.new(@user_2).can?(:delete, @comment)
-  end
-
-  test "unauthenticated guest cannot delete a Comment" do
-    refute Ability.new(nil).can?(:delete, @comment)
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,4 +4,24 @@ class UserTest < ActiveSupport::TestCase
   # test "the truth" do
   #   assert true
   # end
+
+  test "user will be assigned default role on creation" do
+    user = User.new
+    user.save
+
+    assert_equal User.default_auth_role, user.auth_role
+  end
+
+  test "user role can be assigned ahead of time" do
+    user = User.new(auth_role: "banned")
+    user.save
+
+    assert_equal "banned", user.auth_role
+  end
+
+  test "user role cannot be invalid" do
+    user = User.new(auth_role: "foo")
+
+    refute user.valid?
+  end
 end


### PR DESCRIPTION
### Create `auth_roles` for Users and Set "banned"/"admin" Authorizations

This PR adds the `auth_role` column to the `User` model. This allows us to control authorization with CanCanCan. Currently, we have defined what "banned" and "admin" users can and cannot do in the `ability.rb` file. Test coverage for these new roles ("banned"/"admin") have been created as well. Some of the test files were reorganized for logistical reasons. 

![capture_gif](https://user-images.githubusercontent.com/74803363/138007791-b1912b5e-a19b-444c-9c1a-c61bec249d26.gif)
* The logged in user in the above gif is an "admin."

Co-authored-by: Andrew Nordman cadwallion@users.noreply.github.com