### PR TITLE
Implement moderation tools

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -8,6 +8,7 @@ class CategoriesController < ApplicationController
 
   # GET /categories/1 or /categories/1.json
   def show
+    @discussions = @category.discussions.pinned.order(created_at: :desc) + @category.discussions.unpinned.order(created_at: :desc)
   end
 
   # GET /categories/new

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -31,9 +31,24 @@ class CommentsController < ApplicationController
   end
 
   def edit
+    @comment = Comment.find(params[:id])
+    unless can? :update, @comment
+      redirect_back(fallback_location: root_url)
+    end
   end
 
   def update
+    @comment = Comment.find(params[:id])
+    @discussion = @comment.discussion
+    @category = @discussion.category
+
+    respond_to do |format|
+      if can?(:update, @comment) && @comment.update(comment_params)
+        format.html { redirect_to [@category, @discussion], notice: "Comment was successfully updated." }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+      end
+    end
   end
 
   def preview

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -32,6 +32,7 @@ class CommentsController < ApplicationController
 
   def edit
     @comment = Comment.find(params[:id])
+    @discussion = @comment.discussion
     unless can? :update, @comment
       redirect_back(fallback_location: root_url)
     end

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -1,5 +1,5 @@
 class DiscussionsController < ApplicationController
-  before_action :set_category, except: [:destroy, :lock, :unlock]
+  before_action :set_category, except: [:destroy, :lock, :unlock, :pin, :unpin]
   
   def show
     @discussion = Discussion.find(params[:id])
@@ -66,6 +66,40 @@ class DiscussionsController < ApplicationController
           format.html { redirect_to [@category, @discussion], notice: "Discussion was successfully unlocked." }
         else
           format.html { redirect_to [@category, @discussion], notice: "Discussion could not be unlocked.", status: :unprocessable_entity }
+        end
+      else
+        format.html { redirect_to [@category, @discussion], status: 403 }
+      end
+    end
+  end
+
+  def pin
+    @discussion = Discussion.find(params[:id])
+    @category = @discussion.category
+
+    respond_to do |format|
+      if can?(:pin, @discussion)
+        if @discussion.pin
+          format.html { redirect_to [@category, @discussion], notice: "Discussion was successfully pinned." }
+        else
+          format.html { redirect_to [@category, @discussion], notice: "Discussion could not be pinned.", status: :unprocessable_entity }
+        end
+      else
+        format.html { redirect_to [@category, @discussion], status: 403 }
+      end
+    end
+  end
+
+  def unpin
+    @discussion = Discussion.find(params[:id])
+    @category = @discussion.category
+
+    respond_to do |format|
+      if can?(:unpin, @discussion)
+        if @discussion.unpin
+          format.html { redirect_to [@category, @discussion], notice: "Discussion was successfully unpinned." }
+        else
+          format.html { redirect_to [@category, @discussion], notice: "Discussion could not be unpinned.", status: :unprocessable_entity }
         end
       else
         format.html { redirect_to [@category, @discussion], status: 403 }

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -11,6 +11,9 @@ class DiscussionsController < ApplicationController
 
   def edit
     @discussion = Discussion.find(params[:id])
+    unless can? :update, @discussion
+      redirect_back(fallback_location: root_url)
+    end
   end
 
   def create
@@ -30,10 +33,14 @@ class DiscussionsController < ApplicationController
     @discussion = Discussion.find(params[:id])
 
     respond_to do |format|
-      if can?(:update, @discussion) && @discussion.update(discussion_params)
-        format.html { redirect_to [@category, @discussion], notice: "Discussion was successfully updated." }
+      if can?(:update, @discussion)
+        if @discussion.update(discussion_params)
+          format.html { redirect_to [@category, @discussion], notice: "Discussion was successfully updated." }
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+        end
       else
-        format.html { render :new, status: :unprocessable_entity }
+        format.html { redirect_to [@category, @discussion], status: 403 }
       end
     end
   end

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -1,5 +1,5 @@
 class DiscussionsController < ApplicationController
-  before_action :set_category, except: [:destroy, :lock]
+  before_action :set_category, except: [:destroy, :lock, :unlock]
   
   def show
     @discussion = Discussion.find(params[:id])
@@ -49,6 +49,23 @@ class DiscussionsController < ApplicationController
           format.html { redirect_to [@category, @discussion], notice: "Discussion was successfully locked." }
         else
           format.html { redirect_to [@category, @discussion], notice: "Discussion could not be locked.", status: :unprocessable_entity }
+        end
+      else
+        format.html { redirect_to [@category, @discussion], status: 403 }
+      end
+    end
+  end
+
+  def unlock
+    @discussion = Discussion.find(params[:id])
+    @category = @discussion.category
+
+    respond_to do |format|
+      if can?(:unlock, @discussion)
+        if @discussion.unlock
+          format.html { redirect_to [@category, @discussion], notice: "Discussion was successfully unlocked." }
+        else
+          format.html { redirect_to [@category, @discussion], notice: "Discussion could not be unlocked.", status: :unprocessable_entity }
         end
       else
         format.html { redirect_to [@category, @discussion], status: 403 }

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -1,5 +1,5 @@
 class DiscussionsController < ApplicationController
-  before_action :set_category, except: :destroy
+  before_action :set_category, except: [:destroy, :lock]
   
   def show
     @discussion = Discussion.find(params[:id])
@@ -37,6 +37,23 @@ class DiscussionsController < ApplicationController
 
   def set_category
     @category = Category.find(params[:category_id])
+  end
+
+  def lock
+    @discussion = Discussion.find(params[:id])
+    @category = @discussion.category
+
+    respond_to do |format|
+      if can?(:lock, @discussion)
+        if @discussion.lock
+          format.html { redirect_to [@category, @discussion], notice: "Discussion was successfully locked." }
+        else
+          format.html { redirect_to [@category, @discussion], notice: "Discussion could not be locked.", status: :unprocessable_entity }
+        end
+      else
+        format.html { redirect_to [@category, @discussion], status: 403 }
+      end
+    end
   end
 
   private

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -9,6 +9,10 @@ class DiscussionsController < ApplicationController
     @discussion = @category.discussions.build(user: current_user)
   end
 
+  def edit
+    @discussion = Discussion.find(params[:id])
+  end
+
   def create
     @discussion = @category.discussions.build(discussion_params)
     @discussion.user = current_user
@@ -16,6 +20,18 @@ class DiscussionsController < ApplicationController
     respond_to do |format|
       if can?(:create, @discussion) && @discussion.save
         format.html { redirect_to [@category, @discussion], notice: "Discussion was successfully created." }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def update
+    @discussion = Discussion.find(params[:id])
+
+    respond_to do |format|
+      if can?(:update, @discussion) && @discussion.update(discussion_params)
+        format.html { redirect_to [@category, @discussion], notice: "Discussion was successfully updated." }
       else
         format.html { render :new, status: :unprocessable_entity }
       end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,19 +1,44 @@
 class RolesController < ApplicationController
+  before_action :ensure_authorization, only: :index
+
   def index
     # @users = User.where.not(auth_role: "admin")
     @users = User.all
   end
 
   def update
-    if can? :update_roles, User
-      @user = User.find(params[:id])
-      if @user.update(auth_role: params[:user][:auth_role])
-        redirect_to roles_path, notice: "User role updated successfully"
-      else
-        render :index, notice: "Invalid Role assignment: #{@user.errors.full_messages}", status: 422
+    @role = params[:user][:auth_role]
+    @user = User.find(params[:id])
+
+    if @role == "banned"
+      unless can? :ban, @user
+        redirect_back(fallback_location: root_path)
+        return
+      end
+    elsif @user.auth_role == "banned" && @role == "user"
+      unless can? :unban, @user
+        redirect_back(fallback_location: root_path)
+        return
       end
     else
-      redirect_to root_url, status: 403
+      unless can? :update_roles, @user
+        redirect_back(fallback_location: root_path)
+        return
+      end
+    end
+
+    if @user.update(auth_role: @role)
+      flash[:notice] = "User role updated successfully"
+      redirect_back(fallback_location: root_path)
+    else
+      flash[:notice] = "Invalid Role assignment: #{@user.errors.full_messages}"
+      redirect_back(fallback_location: root_path)
+    end
+  end
+
+  def ensure_authorization
+    unless current_user && can?(:update_roles, User)
+      redirect_back(fallback_location: root_path)
     end
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -35,7 +35,7 @@ docReady(function() {
       document.getElementById("comment-form-toggle").classList.remove("active");
       document.getElementById("comment-preview-toggle").classList.add("active");
 
-      let content = document.getElementById("comment_body").value;
+      let content = document.getElementsByClassName("previewable-body")[0].value;
       let csrf_token = document.getElementsByName("authenticity_token")[0].value;
       fetch("/comments/preview", {
           method: "POST",
@@ -59,13 +59,6 @@ docReady(function() {
       document.getElementById("comment-form").style.display = "block";
       document.getElementById("comment-form-toggle").classList.add("active");
       document.getElementById("comment-preview-toggle").classList.remove("active");
-    });
-  }
-
-  let roleDropdown = document.getElementsByClassName("role-dropdown");
-  for(var i = 0, len=roleDropdown.length; i < len; i=i+1|0) {
-    roleDropdown[i].addEventListener("change", (event) => {
-      event.target.parentElement.submit();
     });
   }
 });

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -66,5 +66,14 @@ class Ability
       can :ban, User
       can :unban, User
     end
+
+    if user.auth_role == "moderator"
+      can :lock, Discussion
+      can :unlock, Discussion
+      can :delete, Discussion
+      can :ban, User
+      can :unban, User
+      can :delete, Comment
+    end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -57,6 +57,7 @@ class Ability
       can :create, Discussion
       can :delete, Discussion
       can :update, Discussion
+      can :lock, Discussion
       can :update, Comment
       can :delete, Comment
       can :create, Comment

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -63,6 +63,7 @@ class Ability
       can :delete, Comment
       can :create, Comment
       can :update_roles, User
+      can :ban, User
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -64,6 +64,7 @@ class Ability
       can :create, Comment
       can :update_roles, User
       can :ban, User
+      can :unban, User
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -58,6 +58,7 @@ class Ability
       can :delete, Discussion
       can :update, Discussion
       can :lock, Discussion
+      can :unlock, Discussion
       can :update, Comment
       can :delete, Comment
       can :create, Comment

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -65,6 +65,8 @@ class Ability
       can :update_roles, User
       can :ban, User
       can :unban, User
+      can :pin, Discussion
+      can :unpin, Discussion
     end
 
     if user.auth_role == "moderator"
@@ -74,6 +76,8 @@ class Ability
       can :ban, User
       can :unban, User
       can :delete, Comment
+      can :pin, Discussion
+      can :unpin, Discussion
     end
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < ApplicationRecord
-  has_many :discussions
+  has_many :discussions, dependent: :destroy
 
   validates :name, presence: true
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -1,13 +1,16 @@
 class Discussion < ApplicationRecord
   belongs_to :user
   belongs_to :category
-  has_many :comments
+  has_many :comments, dependent: :destroy
 
   validates :category, presence: true
   validates :user, presence: true
   validates :body, presence: true
 
   before_save :assign_formatted_body, if: -> { body_changed? }
+
+  scope :pinned, -> { where(pinned: true) }
+  scope :unpinned, -> { where(pinned: false) }
 
   def assign_formatted_body
     assign_attributes(formatted_body: MarkdownRenderer.render(body))

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -12,4 +12,12 @@ class Discussion < ApplicationRecord
   def assign_formatted_body
     assign_attributes(formatted_body: MarkdownRenderer.render(body))
   end
+
+  def lock
+    update(locked: true)
+  end
+
+  def unlock
+    update(locked: false)
+  end
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -20,4 +20,12 @@ class Discussion < ApplicationRecord
   def unlock
     update(locked: false)
   end
+
+  def pin
+    update(pinned: true)
+  end
+
+  def unpin
+    update(pinned: false)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,10 @@ class User < ApplicationRecord
     comments.count + discussions.count 
   end
 
+  def banned?
+    auth_role == "banned"
+  end
+
   def self.default_auth_role
     "user"
   end

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -18,7 +18,7 @@
 
 <%= link_to "Create Discussion", new_category_discussion_path(@category) %>
 
-<% @category.discussions.each do |discussion| %>
+<% @discussions.each do |discussion| %>
 <div class="grid grid-cols-6 border rounded m-4 p-4">
   <div class="col-span-5">
     <h1 class="text-lg font-bold"><%= link_to(discussion.title, [@category, discussion]) %></h1>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for(comment) do |form| %>
-  <%= form.input :body %>
+  <%= form.input :body, input_html: { class: "previewable-body" } %>
   <%= form.input :discussion_id, as: "hidden" %>
   <%= form.button :submit, "Submit", class: "border rounded" %>
 <% end %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,12 +1,12 @@
 <h1>Edit Comment</h1>
 
 <ul class="flex justify-left items-left mt-4">
-    <li class="cursor-pointer border b-6 text-gray-500 p-2 active bg-gray-200" id="comment-form-toggle">Write</li>
-    <li class="cursor-pointer border b-6 text-gray-500 p-2 bg-gray-200" id="comment-preview-toggle">Preview</li>
+  <li class="cursor-pointer border b-6 text-gray-500 p-2 active bg-gray-200" id="comment-form-toggle">Write</li>
+  <li class="cursor-pointer border b-6 text-gray-500 p-2 bg-gray-200" id="comment-preview-toggle">Preview</li>
 </ul>
 <div class="border b-2 p-4 comment-pane">
-    <div class="comment-pane-content bg-white" id="comment-form">
+  <div class="comment-pane-content bg-white" id="comment-form">
     <%= render "form", discussion: @comment.discussion, comment: @comment %>
-    </div>
-    <div class="comment-pane-content bg-white" id="comment-preview"></div>
+  </div>
+  <div class="comment-pane-content bg-white" id="comment-preview"></div>
 </div>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,0 +1,12 @@
+<h1>Edit Comment</h1>
+
+<ul class="flex justify-left items-left mt-4">
+    <li class="cursor-pointer border b-6 text-gray-500 p-2 active bg-gray-200" id="comment-form-toggle">Write</li>
+    <li class="cursor-pointer border b-6 text-gray-500 p-2 bg-gray-200" id="comment-preview-toggle">Preview</li>
+</ul>
+<div class="border b-2 p-4 comment-pane">
+    <div class="comment-pane-content bg-white" id="comment-form">
+    <%= render "form", discussion: @comment.discussion, comment: @comment %>
+    </div>
+    <div class="comment-pane-content bg-white" id="comment-preview"></div>
+</div>

--- a/app/views/discussions/_form.html.erb
+++ b/app/views/discussions/_form.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for([@category, @discussion]) do |form| %>
   <%= form.input :title %>
-  <%= form.input :body %>
+  <%= form.input :body, input_html: { class: "previewable-body" } %>
   <%= form.button :submit, "Submit", class: "border rounded" %>
 <% end %>

--- a/app/views/discussions/edit.html.erb
+++ b/app/views/discussions/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Edit Discussion</h1>
+
+<%= render "form" %>

--- a/app/views/discussions/edit.html.erb
+++ b/app/views/discussions/edit.html.erb
@@ -1,3 +1,11 @@
 <h1>Edit Discussion</h1>
-
-<%= render "form" %>
+<ul class="flex justify-left items-left mt-4">
+    <li class="cursor-pointer border b-6 text-gray-500 p-2 active bg-gray-200" id="comment-form-toggle">Write</li>
+    <li class="cursor-pointer border b-6 text-gray-500 p-2 bg-gray-200" id="comment-preview-toggle">Preview</li>
+</ul>
+<div class="border b-2 p-4 comment-pane">
+    <div class="comment-pane-content bg-white" id="comment-form">
+    <%= render "form" %>
+    </div>
+    <div class="comment-pane-content bg-white" id="comment-preview"></div>
+</div>

--- a/app/views/discussions/new.html.erb
+++ b/app/views/discussions/new.html.erb
@@ -1,3 +1,12 @@
 <h1>New Discussion</h1>
 
-<%= render "form" %>
+<ul class="flex justify-left items-left mt-4">
+    <li class="cursor-pointer border b-6 text-gray-500 p-2 active bg-gray-200" id="comment-form-toggle">Write</li>
+    <li class="cursor-pointer border b-6 text-gray-500 p-2 bg-gray-200" id="comment-preview-toggle">Preview</li>
+</ul>
+<div class="border b-2 p-4 comment-pane">
+    <div class="comment-pane-content bg-white" id="comment-form">
+    <%= render "form" %>
+    </div>
+    <div class="comment-pane-content bg-white" id="comment-preview"></div>
+</div>

--- a/app/views/shared/_show_postable.html.erb
+++ b/app/views/shared/_show_postable.html.erb
@@ -7,11 +7,20 @@
       </div>
       <div class="flex justify-between">
         <div>
-          <% if can? :lock, postable %>
-            <%= button_to "Lock",
-              lock_discussion_path(postable),
-              data: { confirm: "Are you sure you want to lock this #{postable.class.to_s.humanize}?" },
-              class: "border rounded mx-1 bg-yellow-500 hover:bg-yellow-500 text-white hover:bg-yellow-500 cursor-pointer p-1" %>
+          <% if postable.respond_to?(:locked) && !postable.locked %>
+            <% if can? :lock, postable %>
+              <%= button_to "Lock",
+                lock_discussion_path(postable),
+                data: { confirm: "Are you sure you want to lock this #{postable.class.to_s.humanize}?" },
+                class: "border rounded mx-1 bg-yellow-500 hover:bg-yellow-500 text-white hover:bg-yellow-500 cursor-pointer p-1" %>
+            <% end %>
+          <% else %>
+            <% if can? :unlock, postable %>
+              <%= button_to "Unlock",
+                unlock_discussion_path(postable),
+                data: { confirm: "Are you sure you want to unlock this #{postable.class.to_s.humanize}?" },
+                class: "border rounded mx-1 bg-yellow-500 hover:bg-yellow-500 text-white hover:bg-yellow-500 cursor-pointer p-1" %>
+            <% end %>
           <% end %>
         </div>
         <div>

--- a/app/views/shared/_show_postable.html.erb
+++ b/app/views/shared/_show_postable.html.erb
@@ -1,18 +1,28 @@
 <div class="grid grid-cols-6 border rounded m-4 p-4 border-gray-500">
   <%= render "shared/user_info", postable: postable %>
   <div class="col-span-5">
-    <div class="grid grid-cols-6 content-center items-center border-b-2"> 
-      <div class="col-span-5 mx-1">
+    <div class="grid grid-cols-6 content-center items-center border-b-2 justify-end"> 
+      <div class="col-span-5 mx-1 justify-self-start">
         Posted on <%= postable.created_at.strftime("%d %b %y %H:%M %Z") %>
       </div>
-      <div class="justify-self-end">
-        <% if can? :delete, postable %>
-          <%= button_to "Delete",
-            postable,
-            method: :delete,
-            data: { confirm: "Are you sure you want to delete?"},
-            class: "border rounded mx-1 bg-red-500 hover:bg-red-700 text-white hover:bg-red-700 cursor-pointer p-1" %>
-        <% end %>
+      <div class="flex justify-between">
+        <div>
+          <% if can? :lock, postable %>
+            <%= button_to "Lock",
+              lock_discussion_path(postable),
+              data: { confirm: "Are you sure you want to lock this #{postable.class.to_s.humanize}?" },
+              class: "border rounded mx-1 bg-yellow-500 hover:bg-yellow-500 text-white hover:bg-yellow-500 cursor-pointer p-1" %>
+          <% end %>
+        </div>
+        <div>
+          <% if can? :delete, postable %>
+            <%= button_to "Delete",
+              postable,
+              method: :delete,
+              data: { confirm: "Are you sure you want to delete?"},
+              class: "border rounded mx-1 bg-red-500 hover:bg-red-700 text-white hover:bg-red-700 cursor-pointer p-1" %>
+          <% end %>
+        </div>
       </div>
     </div>
     <%= postable.formatted_body.html_safe %>

--- a/app/views/shared/_show_postable.html.erb
+++ b/app/views/shared/_show_postable.html.erb
@@ -7,19 +7,40 @@
       </div>
       <div class="flex justify-between">
         <div>
+          <% if postable.respond_to?(:pinned) && !postable.pinned %>
+            <% if can? :pin, postable %>
+              <%= button_to "Pin",
+                pin_discussion_path(postable),
+                data: { confirm: "Are you sure you want to pin this #{postable.class.to_s.humanize}?" },
+                class: "border rounded mx-1 bg-green-500 hover:bg-green-700 text-white hover:bg-green-500 cursor-pointer p-1"
+              %>
+            <% end %>
+          <% else %>
+            <% if can? :unpin, postable %>
+              <%= button_to "Unpin",
+                unpin_discussion_path(postable),
+                data: { confirm: "Are you sure you want to unpin this #{postable.class.to_s.humanize}?" },
+                class: "border rounded mx-1 bg-green-500 hover:bg-green-700 text-white hover:bg-green-500 cursor-pointer p-1"
+              %>
+            <% end %>
+          <% end %>
+        </div>
+        <div>
           <% if postable.respond_to?(:locked) && !postable.locked %>
             <% if can? :lock, postable %>
               <%= button_to "Lock",
                 lock_discussion_path(postable),
                 data: { confirm: "Are you sure you want to lock this #{postable.class.to_s.humanize}?" },
-                class: "border rounded mx-1 bg-yellow-500 hover:bg-yellow-500 text-white hover:bg-yellow-500 cursor-pointer p-1" %>
+                class: "border rounded mx-1 bg-yellow-500 hover:bg-yellow-700 text-white hover:bg-yellow-500 cursor-pointer p-1"
+              %>
             <% end %>
           <% else %>
             <% if can? :unlock, postable %>
               <%= button_to "Unlock",
                 unlock_discussion_path(postable),
                 data: { confirm: "Are you sure you want to unlock this #{postable.class.to_s.humanize}?" },
-                class: "border rounded mx-1 bg-yellow-500 hover:bg-yellow-500 text-white hover:bg-yellow-500 cursor-pointer p-1" %>
+                class: "border rounded mx-1 bg-yellow-500 hover:bg-yellow-700 text-white hover:bg-yellow-500 cursor-pointer p-1"
+              %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/shared/_show_postable.html.erb
+++ b/app/views/shared/_show_postable.html.erb
@@ -2,10 +2,10 @@
   <%= render "shared/user_info", postable: postable %>
   <div class="col-span-5">
     <div class="grid grid-cols-6 content-center items-center border-b-2 justify-end"> 
-      <div class="col-span-5 mx-1 justify-self-start">
+      <div class="col-span-4 mx-1 justify-self-start">
         Posted on <%= postable.created_at.strftime("%d %b %y %H:%M %Z") %>
       </div>
-      <div class="flex justify-between">
+      <div class="col-span-2 flex justify-end">
         <div>
           <% if postable.respond_to?(:pinned) && !postable.pinned %>
             <% if can? :pin, postable %>
@@ -42,6 +42,14 @@
                 class: "border rounded mx-1 bg-yellow-500 hover:bg-yellow-700 text-white hover:bg-yellow-500 cursor-pointer p-1"
               %>
             <% end %>
+          <% end %>
+        </div>
+        <div>
+          <% if can? :update, postable %>
+            <%= button_to "Edit",
+              { action: "edit", controller: postable.class.name.pluralize.downcase, id: postable.id },
+              method: :get,
+              class: "border rounded mx-1 bg-blue-500 hover:bg-blue-700 text-white hover:bg-blue-700 cursor-pointer p-1" %>
           <% end %>
         </div>
         <div>

--- a/app/views/shared/_user_info.html.erb
+++ b/app/views/shared/_user_info.html.erb
@@ -10,5 +10,13 @@
         data: { confirm: "Are you sure you want to ban this user?" },
         class: "border rounded mx-1 bg-yellow-500 hover:bg-yellow-500 text-white hover:bg-yellow-500 cursor-pointer p-1" %>
     <% end %>
+  <% else %>
+    <% if can? :unban, postable.user %> 
+      <%= button_to "Unban",
+        role_path(postable.user, user: { auth_role: "user" }),
+        method: :patch,
+        data: { confirm: "Are you sure you want to unban this user?" },
+        class: "border rounded mx-1 bg-yellow-500 hover:bg-yellow-500 text-white hover:bg-yellow-500 cursor-pointer p-1" %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/shared/_user_info.html.erb
+++ b/app/views/shared/_user_info.html.erb
@@ -2,4 +2,13 @@
   <div><%= user_avatar(postable.user, width: 64) %></div>
   <div><%= postable.user.login %></div>
   <div>Posts: <%= postable.user.post_count %></div>
+  <% if !postable.user.banned? %>
+    <% if can? :ban, postable.user %> 
+      <%= button_to "Ban",
+        role_path(postable.user, user: { auth_role: "banned" }),
+        method: :patch,
+        data: { confirm: "Are you sure you want to ban this user?" },
+        class: "border rounded mx-1 bg-yellow-500 hover:bg-yellow-500 text-white hover:bg-yellow-500 cursor-pointer p-1" %>
+    <% end %>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,12 @@ Rails.application.routes.draw do
 
   # DISCUSSION
   resources :discussions, only: :destroy do
-    post :lock, on: :member
-    post :unlock, on: :member
+    member do
+      post :lock
+      post :unlock
+      post :pin
+      post :unpin
+    end
   end
 
   # COMMENT

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,9 @@ Rails.application.routes.draw do
   end
 
   # DISCUSSION
-  resources :discussions, only: :destroy
+  resources :discussions, only: :destroy do
+    post :lock, on: :member
+  end
 
   # COMMENT
   resources :comments, only: [:create, :destroy, :edit, :update] do 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   end
 
   # DISCUSSION
-  resources :discussions, only: :destroy do
+  resources :discussions, only: [:edit, :update, :destroy] do
     member do
       post :lock
       post :unlock

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   # DISCUSSION
   resources :discussions, only: :destroy do
     post :lock, on: :member
+    post :unlock, on: :member
   end
 
   # COMMENT

--- a/test/fixtures/discussions.yml
+++ b/test/fixtures/discussions.yml
@@ -1,17 +1,2 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  title: MyString
-  body: MyString
-  user: one
-  category: one
-  pinned: false
-  locked: false
-
-two:
-  title: MyString
-  body: MyString
-  user: two
-  category: two
-  pinned: false
-  locked: false

--- a/test/models/abilities/admin_test.rb
+++ b/test/models/abilities/admin_test.rb
@@ -84,4 +84,8 @@ class Ability::AdminTest < ActiveSupport::TestCase
   test "can change auth_role of another user" do
     assert Ability.new(@user).can?(:update_roles, @user_2)
   end
+
+  test "can lock a Discussion" do
+    assert Ability.new(@user).can?(:lock, @discussion)
+  end
 end

--- a/test/models/abilities/admin_test.rb
+++ b/test/models/abilities/admin_test.rb
@@ -92,4 +92,8 @@ class Ability::AdminTest < ActiveSupport::TestCase
   test "can unlock a Discussion" do
     assert Ability.new(@user).can?(:unlock, @discussion)
   end
+
+  test "can ban a User" do
+    assert Ability.new(@user).can?(:ban, @user_2)
+  end
 end

--- a/test/models/abilities/admin_test.rb
+++ b/test/models/abilities/admin_test.rb
@@ -100,4 +100,12 @@ class Ability::AdminTest < ActiveSupport::TestCase
   test "can unban a User" do
     assert Ability.new(@user).can?(:unban, @user_2)
   end
+
+  test "can pin a Discussion" do
+    assert Ability.new(@user).can?(:pin, @discussion)
+  end
+
+  test "can unpin a Discussion" do
+    assert Ability.new(@user).can?(:unpin, @discussion)
+  end
 end

--- a/test/models/abilities/admin_test.rb
+++ b/test/models/abilities/admin_test.rb
@@ -96,4 +96,8 @@ class Ability::AdminTest < ActiveSupport::TestCase
   test "can ban a User" do
     assert Ability.new(@user).can?(:ban, @user_2)
   end
+
+  test "can unban a User" do
+    assert Ability.new(@user).can?(:unban, @user_2)
+  end
 end

--- a/test/models/abilities/admin_test.rb
+++ b/test/models/abilities/admin_test.rb
@@ -88,4 +88,8 @@ class Ability::AdminTest < ActiveSupport::TestCase
   test "can lock a Discussion" do
     assert Ability.new(@user).can?(:lock, @discussion)
   end
+
+  test "can unlock a Discussion" do
+    assert Ability.new(@user).can?(:unlock, @discussion)
+  end
 end

--- a/test/models/abilities/authenticated_user_test.rb
+++ b/test/models/abilities/authenticated_user_test.rb
@@ -89,4 +89,8 @@ class Ability::AuthenticatedUserTest < ActiveSupport::TestCase
   test "cannot unlock a Discussion" do
     refute Ability.new(@user).can?(:unlock, @discussion)
   end
+
+  test "cannot ban a User" do
+    refute Ability.new(@user).can?(:ban, @user_2)
+  end
 end

--- a/test/models/abilities/authenticated_user_test.rb
+++ b/test/models/abilities/authenticated_user_test.rb
@@ -97,4 +97,12 @@ class Ability::AuthenticatedUserTest < ActiveSupport::TestCase
   test "cannot unban a User" do
     refute Ability.new(@user).can?(:unban, @user_2)
   end
+
+  test "cannot pin a Discussion" do
+    refute Ability.new(@user).can?(:pin, @discussion)
+  end
+
+  test "cannot unpin a Discussion" do
+    refute Ability.new(@user).can?(:unpin, @discussion)
+  end
 end

--- a/test/models/abilities/authenticated_user_test.rb
+++ b/test/models/abilities/authenticated_user_test.rb
@@ -85,4 +85,8 @@ class Ability::AuthenticatedUserTest < ActiveSupport::TestCase
   test "cannot lock a Discussion" do
     refute Ability.new(@user).can?(:lock, @discussion)
   end
+
+  test "cannot unlock a Discussion" do
+    refute Ability.new(@user).can?(:unlock, @discussion)
+  end
 end

--- a/test/models/abilities/authenticated_user_test.rb
+++ b/test/models/abilities/authenticated_user_test.rb
@@ -93,4 +93,8 @@ class Ability::AuthenticatedUserTest < ActiveSupport::TestCase
   test "cannot ban a User" do
     refute Ability.new(@user).can?(:ban, @user_2)
   end
+
+  test "cannot unban a User" do
+    refute Ability.new(@user).can?(:unban, @user_2)
+  end
 end

--- a/test/models/abilities/authenticated_user_test.rb
+++ b/test/models/abilities/authenticated_user_test.rb
@@ -81,4 +81,8 @@ class Ability::AuthenticatedUserTest < ActiveSupport::TestCase
   test "cannot update role for anyone" do
     refute Ability.new(@user).can?(:update_roles, @user_2)
   end
+
+  test "cannot lock a Discussion" do
+    refute Ability.new(@user).can?(:lock, @discussion)
+  end
 end

--- a/test/models/abilities/banned_test.rb
+++ b/test/models/abilities/banned_test.rb
@@ -76,4 +76,12 @@ class Ability::BannedTest < ActiveSupport::TestCase
   test "cannot unban a User" do
     refute Ability.new(@user).can?(:unban, @user_2)
   end
+
+  test "cannot pin a Discussion" do
+    refute Ability.new(@user).can?(:pin, @discussion)
+  end
+
+  test "cannot unpin a Discussion" do
+    refute Ability.new(@user).can?(:unpin, @discussion)
+  end
 end

--- a/test/models/abilities/banned_test.rb
+++ b/test/models/abilities/banned_test.rb
@@ -72,4 +72,8 @@ class Ability::BannedTest < ActiveSupport::TestCase
   test "cannot ban a User" do
     refute Ability.new(@user).can?(:ban, @user_2)
   end
+
+  test "cannot unban a User" do
+    refute Ability.new(@user).can?(:unban, @user_2)
+  end
 end

--- a/test/models/abilities/banned_test.rb
+++ b/test/models/abilities/banned_test.rb
@@ -68,4 +68,8 @@ class Ability::BannedTest < ActiveSupport::TestCase
   test "cannot unlock a Discussion" do
     refute Ability.new(@user).can?(:unlock, @discussion)
   end
+
+  test "cannot ban a User" do
+    refute Ability.new(@user).can?(:ban, @user_2)
+  end
 end

--- a/test/models/abilities/banned_test.rb
+++ b/test/models/abilities/banned_test.rb
@@ -60,4 +60,8 @@ class Ability::BannedTest < ActiveSupport::TestCase
   test "cannot update role for anyone" do
     refute Ability.new(@user).can?(:update_roles, @user_2)
   end
+
+  test "cannot lock a Discussion" do
+    refute Ability.new(@user).can?(:lock, @discussion)
+  end
 end

--- a/test/models/abilities/banned_test.rb
+++ b/test/models/abilities/banned_test.rb
@@ -64,4 +64,8 @@ class Ability::BannedTest < ActiveSupport::TestCase
   test "cannot lock a Discussion" do
     refute Ability.new(@user).can?(:lock, @discussion)
   end
+
+  test "cannot unlock a Discussion" do
+    refute Ability.new(@user).can?(:unlock, @discussion)
+  end
 end

--- a/test/models/abilities/guest_test.rb
+++ b/test/models/abilities/guest_test.rb
@@ -64,4 +64,12 @@ class Ability::GuestTest < ActiveSupport::TestCase
   test "cannot unban a User" do
     refute Ability.new(nil).can?(:unban, @user_2)
   end
+
+  test "cannot pin a Discussion" do
+    refute Ability.new(@user).can?(:pin, @discussion)
+  end
+
+  test "cannot unpin a Discussion" do
+    refute Ability.new(@user).can?(:unpin, @discussion)
+  end
 end

--- a/test/models/abilities/guest_test.rb
+++ b/test/models/abilities/guest_test.rb
@@ -60,4 +60,8 @@ class Ability::GuestTest < ActiveSupport::TestCase
   test "cannot ban a User" do
     refute Ability.new(nil).can?(:ban, @user_2)
   end
+
+  test "cannot unban a User" do
+    refute Ability.new(nil).can?(:unban, @user_2)
+  end
 end

--- a/test/models/abilities/guest_test.rb
+++ b/test/models/abilities/guest_test.rb
@@ -52,4 +52,8 @@ class Ability::GuestTest < ActiveSupport::TestCase
   test "cannot lock a Discussion" do
     refute Ability.new(@user).can?(:lock, @discussion)
   end
+
+  test "cannot unlock a Discussion" do
+    refute Ability.new(@user).can?(:unlock, @discussion)
+  end
 end

--- a/test/models/abilities/guest_test.rb
+++ b/test/models/abilities/guest_test.rb
@@ -48,4 +48,8 @@ class Ability::GuestTest < ActiveSupport::TestCase
   test "cannot update role for anyone" do
     refute Ability.new(nil).can?(:update_roles, @user_2)
   end
+
+  test "cannot lock a Discussion" do
+    refute Ability.new(@user).can?(:lock, @discussion)
+  end
 end

--- a/test/models/abilities/guest_test.rb
+++ b/test/models/abilities/guest_test.rb
@@ -50,10 +50,14 @@ class Ability::GuestTest < ActiveSupport::TestCase
   end
 
   test "cannot lock a Discussion" do
-    refute Ability.new(@user).can?(:lock, @discussion)
+    refute Ability.new(nil).can?(:lock, @discussion)
   end
 
   test "cannot unlock a Discussion" do
-    refute Ability.new(@user).can?(:unlock, @discussion)
+    refute Ability.new(nil).can?(:unlock, @discussion)
+  end
+
+  test "cannot ban a User" do
+    refute Ability.new(nil).can?(:ban, @user_2)
   end
 end

--- a/test/models/abilities/moderator_test.rb
+++ b/test/models/abilities/moderator_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class Ability::ModeratorTest < ActiveSupport::TestCase
+  def setup
+    @category = Category.new
+    @user = User.new(auth_role: "moderator")
+    @user_2 = User.new
+    @discussion = @category.discussions.build(user: @user)
+    @discussion2 = @category.discussions.build(user: @user_2)
+    @comment = @discussion.comments.build(user: @user, body: "This is a test")
+    @comment2 = @discussion2.comments.build(user: @user_2, body: "This is a test")
+  end
+
+  test "can read all Category" do
+    assert Ability.new(@user).can?(:read, @category)
+  end
+
+  test "can read all Discussions" do
+    assert Ability.new(@user).can?(:read, @discussion)
+  end
+
+  test "can create a Discussion made by themselves" do
+    assert Ability.new(@user).can?(:create, @discussion)
+  end
+
+  test "can delete their own Discussion" do
+    assert Ability.new(@user).can?(:delete, @discussion)
+  end
+
+  test "can delete a Discussion made by someone else" do
+    assert Ability.new(@user).can?(:delete, @discussion2)
+  end
+
+  test "can update their own Discussion" do
+    assert Ability.new(@user).can?(:update, @discussion)
+  end
+
+  test "can update their own Comment" do
+    assert Ability.new(@user).can?(:update, @comment)
+  end
+
+  test "can read all Comments" do
+    assert Ability.new(@user).can?(:read, @comment)
+  end
+
+  test "can create a Comment" do
+    assert Ability.new(@user).can?(:create, @comment)
+  end
+
+  test "can delete a Comment" do
+    assert Ability.new(@user).can?(:delete, @comment)
+  end
+
+  test "can delete a Comment made by someone else" do
+    assert Ability.new(@user).can?(:delete, @comment2)
+  end
+
+  test "can lock a Discussion" do
+    assert Ability.new(@user).can?(:lock, @discussion)
+  end
+
+  test "can unlock a Discussion" do
+    assert Ability.new(@user).can?(:unlock, @discussion)
+  end
+
+  test "can ban a User" do
+    assert Ability.new(@user).can?(:ban, @user_2)
+  end
+
+  test "can unban a User" do
+    assert Ability.new(@user).can?(:unban, @user_2)
+  end
+end

--- a/test/models/abilities/moderator_test.rb
+++ b/test/models/abilities/moderator_test.rb
@@ -70,4 +70,12 @@ class Ability::ModeratorTest < ActiveSupport::TestCase
   test "can unban a User" do
     assert Ability.new(@user).can?(:unban, @user_2)
   end
+
+  test "can pin a Discussion" do
+    assert Ability.new(@user).can?(:pin, @discussion)
+  end
+
+  test "can unpin a Discussion" do
+    assert Ability.new(@user).can?(:unpin, @discussion)
+  end
 end

--- a/test/models/discussion_test.rb
+++ b/test/models/discussion_test.rb
@@ -12,6 +12,7 @@ class DiscussionTest < ActiveSupport::TestCase
 
   def teardown
     Category.destroy_all
+    Discussion.destroy_all
   end
 
   test "is valid" do

--- a/test/models/discussion_test.rb
+++ b/test/models/discussion_test.rb
@@ -36,4 +36,20 @@ class DiscussionTest < ActiveSupport::TestCase
     refute discussion.valid?
     assert_not_nil discussion.errors[:body], 'no validation error for body present'
   end
+
+  test "lock sets locked to true" do
+    discussion = Discussion.new(category: @category, user: @user, body: nil)
+    refute discussion.locked
+
+    discussion.lock
+    assert discussion.locked
+  end
+
+  test "unlock sets locked to false" do
+    discussion = Discussion.new(category: @category, user: @user, body: nil, locked: true)
+    assert discussion.locked
+
+    discussion.unlock
+    refute discussion.locked
+  end
 end

--- a/test/models/discussion_test.rb
+++ b/test/models/discussion_test.rb
@@ -6,8 +6,12 @@ class DiscussionTest < ActiveSupport::TestCase
   # end
 
   def setup
-    @category = Category.new
+    @category = Category.new(name: "Important Stuff")
     @user = User.new
+  end
+
+  def teardown
+    Category.destroy_all
   end
 
   test "is valid" do
@@ -67,5 +71,23 @@ class DiscussionTest < ActiveSupport::TestCase
 
     discussion.unpin
     refute discussion.pinned
+  end
+
+  test "pinned scope returns only pinned Discussions" do
+    @category.save
+    @user.save
+    discussion_pinned = Discussion.create!(category: @category, user: @user, body: "Important Stuff in here", pinned: true)
+    discussion_unpinned = Discussion.create!(category: @category, user: @user, body: "lol memes", pinned: false)
+
+    assert_equal [discussion_pinned], Discussion.pinned.all.to_a
+  end
+
+  test "unpinned scope returns only unpinned Discussions" do
+    @category.save
+    @user.save
+    discussion_pinned = Discussion.create!(category: @category, user: @user, body: "Important Stuff in here", pinned: true)
+    discussion_unpinned = Discussion.create!(category: @category, user: @user, body: "lol memes", pinned: false)
+
+    assert_equal [discussion_unpinned], Discussion.unpinned.all.to_a
   end
 end

--- a/test/models/discussion_test.rb
+++ b/test/models/discussion_test.rb
@@ -52,4 +52,20 @@ class DiscussionTest < ActiveSupport::TestCase
     discussion.unlock
     refute discussion.locked
   end
+
+  test "pin sets pinned to true" do
+    discussion = Discussion.new(category: @category, user: @user, body: nil, pinned: false)
+    refute discussion.pinned
+
+    discussion.pin
+    assert discussion.pinned
+  end
+
+  test "unpin sets pinned to false" do
+    discussion = Discussion.new(category: @category, user: @user, body: nil, pinned: true)
+    assert discussion.pinned
+
+    discussion.unpin
+    refute discussion.pinned
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -24,4 +24,16 @@ class UserTest < ActiveSupport::TestCase
 
     refute user.valid?
   end
+
+  test "banned returns true when role is set to banned" do
+    user = User.new(auth_role: "banned")
+
+    assert user.banned?
+  end
+
+  test "banned returns false when role is not set to banned" do
+    user = User.new
+
+    refute user.banned?
+  end
 end


### PR DESCRIPTION
### Introduce moderation tools

This PR adds the moderator role and the ability for moderation to happen by adding "pin/unpin, lock/unlock, and edit" buttons to a discussion. It also adds the ability for admins and moderators to ban/unban users. The edit/new form partials were also updated so the "write/preview" functionality works  for comments and discussions. Full test coverage for all new implementations also added.

Resolves #11 

![capture_gif](https://user-images.githubusercontent.com/74803363/138371164-2b018712-ec0f-4660-bb6d-07a59e1ce551.gif)