### PR TITLE
Add `:create` ability for admins & update tests

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -52,6 +52,7 @@ class Ability
     can :delete, Comment, user: user
 
     if user.auth_role == "admin"
+      can :create, Category
       can :update, Category
       can :delete, Category
       can :create, Discussion

--- a/test/models/abilities/admin_test.rb
+++ b/test/models/abilities/admin_test.rb
@@ -11,6 +11,10 @@ class Ability::AdminTest < ActiveSupport::TestCase
     @comment2 = @discussion2.comments.build(user: @user_2, body: "This is a test")
   end
 
+  test "can create a Cateory" do
+    assert Ability.new(@user).can?(:create, @category)
+  end
+  
   test "can read all Category" do
     assert Ability.new(@user).can?(:read, @category)
   end

--- a/test/models/abilities/authenticated_user_test.rb
+++ b/test/models/abilities/authenticated_user_test.rb
@@ -8,6 +8,10 @@ class Ability::AuthenticatedUserTest < ActiveSupport::TestCase
     @comment = @discussion.comments.build(user: @user, body: "This is a test")
   end
 
+  test "cannot create a Category" do
+    refute Ability.new(@user).can?(:create, @category)
+  end
+
   test "can read all Category" do
     assert Ability.new(@user).can?(:read, @category)
   end

--- a/test/models/abilities/banned_test.rb
+++ b/test/models/abilities/banned_test.rb
@@ -9,6 +9,10 @@ class Ability::BannedTest < ActiveSupport::TestCase
     @comment = @discussion.comments.build(user: @user, body: "This is a test")
   end
 
+  test "cannot create a Category" do
+    refute Ability.new(@user).can?(:create, @category)
+  end
+
   test "cannot read a category" do
     refute Ability.new(@user).can?(:read, @category)
   end

--- a/test/models/abilities/guest_test.rb
+++ b/test/models/abilities/guest_test.rb
@@ -9,6 +9,10 @@ class Ability::GuestTest < ActiveSupport::TestCase
     @comment = @discussion.comments.build(user: @user, body: "This is a test")
   end
 
+  test "cannot create a Category" do
+    refute Ability.new(nil).can?(:create, @category)
+  end
+
   test "can read all Category" do
     assert Ability.new(nil).can?(:read, @category)
   end

--- a/test/models/abilities/moderator_test.rb
+++ b/test/models/abilities/moderator_test.rb
@@ -11,6 +11,10 @@ class Ability::ModeratorTest < ActiveSupport::TestCase
     @comment2 = @discussion2.comments.build(user: @user_2, body: "This is a test")
   end
 
+  test "cannot create a Category" do
+    refute Ability.new(@user).can?(:create, @category)
+  end
+
   test "can read all Category" do
     assert Ability.new(@user).can?(:read, @category)
   end


### PR DESCRIPTION
We missed giving admins the ability to create a Category. This PR fixes that mistake and adds test coverage for all roles reflective of this change.