### PR TITLE
RSpec System Tests:

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.6"
+services: 
+  selenium: 
+    image: "selenium/hub"
+    container_name: "conclave-selenium"
+    ports: 
+      - 4444:4444
+      - 4443:4443
+      - 4442:4442
+    environment:
+      GRID_MAX_SESSION: 10
+  chrome:
+    image: "selenium/node-chrome"
+    deploy:
+      replicas: 4
+    depends_on:
+      - selenium
+    environment:
+      SE_EVENT_BUS_HOST: "conclave-selenium"
+      NODE_MAX_INSTANCES: 5
+      NODE_MAX_SESSION: 5
+      SE_EVENT_BUS_PUBLISH_PORT: 4442
+      SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
+      SE_NODE_GRID_URL: "http://localhost:4444"
+    

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,8 @@ require File.expand_path('../config/environment', __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require "capybara/rails"
+require "capybara/rspec"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -20,7 +22,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -61,4 +63,13 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:google_oauth0] = OmniAuth::AuthHash.new({
+    provider: "google_oauth0",
+    uid: "31413",
+    info: {
+      name: "Test Person"
+    }
+  })
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,28 @@
+Capybara.register_driver :remote_selenium_headless do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("--headless")
+  options.add_argument("--window-size=1400,1400")
+  options.add_argument("--no-sandbox")
+  options.add_argument("--disable-dev-shm-usage")
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    url: "http://localhost:4444/wd/hub",
+    options: options
+  )
+end
+
+Capybara.configure do |config|
+  config.server = :puma, { Silent: true }
+  config.server_host = "0.0.0.0"
+  config.always_include_port = true
+end
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    Capybara.app_host = "http://host.docker.internal:#{Capybara.server_port}"
+
+    driven_by :remote_selenium_headless
+  end
+end

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "login", type: :system do
+  it "succesful" do
+    visit root_path
+    click_on "Login"
+    expect(page).to have_text("Logged in!")
+  end
+end


### PR DESCRIPTION
### RSpec System Tests with Capybara (using WSL2)

This PR sets up the dev environment to use docker so that system specs can be run in a container that communicates with the local app. 

System RSpec tests can now be written.