### PR TITLE
Category system specs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
   end
 
   def page_link_tree(category, discussion)
-    root_link = link_to("Conclave", categories_path, class: "hover:text-yellow-700")
+    root_link = link_to("Categories", categories_path, class: "hover:text-yellow-700")
     category_link = link_to(category.name, category, class: "hover:text-yellow-700")
     discussion_link = link_to(discussion.title, [category, discussion], class: "hover:text-yellow-700") if discussion
     [root_link, category_link, discussion_link].compact.join(" > ").html_safe

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -3,7 +3,7 @@
 <h1>Categories</h1>
 
 <% @categories.each do |category| %>
-  <div class="grid grid-cols-6 border rounded m-4 p-4">
+  <div class="grid grid-cols-6 border rounded m-4 p-4" id="category_<%= category.id %>">
     <div class="col-span-5">
       <h1 class="text-xl font-bold">
         <%= link_to(
@@ -19,6 +19,7 @@
         <%= button_to(
           "Edit",
           edit_category_path(category),
+          method: :get,
           class: "mx-1 p-1 w-16 border rounded cursor-pointer bg-yellow-500 hover:bg-yellow-600 text-white",
         )%>
       <% end %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -4,7 +4,7 @@
   <%= page_link_tree(@category, @discussion) %>
 </h1>
 
-<div class="grid grid-cols-6 border rounded m-4 p-4">
+<div class="grid grid-cols-6 border rounded m-4 p-4" id="category_<%= @category.id %>">
   <div class="col-span-5">
     <h1 class="text-xl font-bold">
       <%= link_to(

--- a/spec/matchers/category_matchers.rb
+++ b/spec/matchers/category_matchers.rb
@@ -1,0 +1,51 @@
+require "rspec/expectations"
+
+module CategoryHelpers
+  extend RSpec::Matchers::DSL
+
+  matcher :have_correct_category_name_on_page do |category_name|
+    match do |actual|
+      expect(actual).to have_text(category_name)
+    end
+    failure_message do |actual|
+      "expected that the category '#{category_name}' would be present on the page."
+    end
+  end
+
+  matcher :have_correct_category_description_on_page do |category_description|
+    match do |actual|
+      expect(actual).to have_text(category_description)
+    end
+    failure_message do |actual|
+      "expected that the category description '#{category_description}' would be present on the page."
+    end
+  end
+
+  matcher :have_correct_message_for_action do |action|
+    match do |actual|
+      expect(actual).to have_text("Category was successfully #{action}.")
+    end
+    failure_message do |actual|
+      "expected that the message 'Category was successfully #{action}.' would be present on the page for the appropriate action."
+    end
+  end
+
+  matcher :have_expected_buttons do
+    match do
+      find_button "Edit"
+      find_button "Create Discussion"
+    end
+    failure_message do
+      "expected that the buttons `Edit` and `Create Discussion` exist on the page."
+    end
+  end
+
+  matcher :have_the_expected_category_header do |category_header|
+    match do |actual|
+      expect(actual).to have_text(category_header)
+    end
+    failure_message do |actual|
+      "expected that the category header '#{category_header}' for the categories table is on the page."
+    end
+  end
+end

--- a/spec/modules/helpers.rb
+++ b/spec/modules/helpers.rb
@@ -10,7 +10,6 @@ module SessionHelpers
 
   def login_as_user
     create_user("user")
-
     visit root_path
     click_on "Login"
     expect(page).to have_text("Logged in!")
@@ -18,7 +17,6 @@ module SessionHelpers
   
   def login_as_moderator
     create_user("moderator")
-
     visit root_path
     find_button "Login"
     click_on "Login"
@@ -27,7 +25,6 @@ module SessionHelpers
 
   def login_as_admin
     create_user("admin")
-
     visit root_path
     click_on "Login"
     expect(page).to have_text("Logged in!")
@@ -41,13 +38,51 @@ module SessionHelpers
 end
 
 module CategoryHelpers
-  def should_be_on_categories_page(category_name, category_description)
-    expect(page).to have_text("Category was successfully created.")
-    expect(page).to have_text("Conclave > #{category_name}")
+  def create_category(category_name, category_description)
+    login_as_admin
+    find_button "New Category"
+    click_on "New Category"
+    find_button "Submit"
+    fill_in("Name", with: category_name)
+    fill_in("Description", with: category_description)
+    click_on "Submit"
+    should_be_on_categories_page(category_name, category_description)
+  end
+
+  def should_be_on_categories_page(category_name, category_description, action = "created")
+    expect(page).to have_text("Category was successfully #{action}.")
+    expect(page).to have_text("Categories > #{category_name}")
     expect(page).to have_text(category_name)
     expect(page).to have_text(category_description)
     find_button "Edit"
     find_button "Create Discussion"
     expect(page).to have_text("DISCUSSION REPLIES LAST POST")
+  end
+
+  def edit_category(updated_name = "New Title", updated_description = "New Description", category_id)
+    within "#category_#{category_id}" do
+      click_on "Edit"
+    end
+    expect(page).to have_text("Editing Category")
+    find_button "Show"
+    find_button "Back"
+    fill_in("Name", with: updated_name)
+    fill_in("Description", with: updated_description)
+    click_on "Submit"
+    should_be_on_categories_page(updated_name, updated_description, "updated")
+  end
+
+  def delete_category(category_name, category_description)
+    category_id = Category.find_by(name: category_name, description: category_description).id
+    click_link("Categories")
+    expect(page).to have_text("Categories")
+    expect(page).to have_text(category_name)
+    expect(page).to have_text(category_description)
+    within "#category_#{category_id}" do
+      click_on "Delete"
+    end
+    page.driver.browser.switch_to.alert.accept
+    expect(page).to have_text("Category was successfully destroyed.")
+    expect(page).not_to have_selector("#category_#{category_id}")
   end
 end

--- a/spec/modules/helpers.rb
+++ b/spec/modules/helpers.rb
@@ -1,0 +1,53 @@
+module SessionHelpers
+  def create_user(role)
+    User.create(
+      login: OmniAuth.config.mock_auth[:google_oauth2][:info][:name],
+      provider: OmniAuth.config.mock_auth[:google_oauth2][:provider],
+      uid: OmniAuth.config.mock_auth[:google_oauth2][:uid],
+      auth_role: role,
+    )
+  end
+
+  def login_as_user
+    create_user("user")
+
+    visit root_path
+    click_on "Login"
+    expect(page).to have_text("Logged in!")
+  end
+  
+  def login_as_moderator
+    create_user("moderator")
+
+    visit root_path
+    find_button "Login"
+    click_on "Login"
+    expect(page).to have_text("Logged in!")
+  end
+
+  def login_as_admin
+    create_user("admin")
+
+    visit root_path
+    click_on "Login"
+    expect(page).to have_text("Logged in!")
+  end
+
+  def logout
+    visit root_path
+    click_on "Logout"
+    expect(page).to have_text("Logged out!")
+  end
+end
+
+module CategoryHelpers
+  def should_be_on_categories_page(category_name, category_description)
+    expect(page).to have_text("Category was successfully created.")
+    expect(page).to have_text("Conclave > #{category_name}")
+    expect(page).to have_text(category_name)
+    expect(page).to have_text(category_description)
+    find_button "Edit"
+    find_button "Create Discussion"
+    expect(page).to have_text("DISCUSSION REPLIES LAST POST")
+  end
+end

--- a/spec/modules/helpers.rb
+++ b/spec/modules/helpers.rb
@@ -8,23 +8,8 @@ module SessionHelpers
     )
   end
 
-  def login_as_user
-    create_user("user")
-    visit root_path
-    click_on "Login"
-    expect(page).to have_text("Logged in!")
-  end
-  
-  def login_as_moderator
-    create_user("moderator")
-    visit root_path
-    find_button "Login"
-    click_on "Login"
-    expect(page).to have_text("Logged in!")
-  end
-
-  def login_as_admin
-    create_user("admin")
+  def login_as(role)
+    create_user(role)
     visit root_path
     click_on "Login"
     expect(page).to have_text("Logged in!")
@@ -39,7 +24,7 @@ end
 
 module CategoryHelpers
   def create_category(category_name, category_description)
-    login_as_admin
+    login_as("admin")
     find_button "New Category"
     click_on "New Category"
     find_button "Submit"

--- a/spec/modules/helpers.rb
+++ b/spec/modules/helpers.rb
@@ -1,3 +1,6 @@
+require 'rspec/expectations'
+require_relative "../matchers/category_matchers"
+
 module SessionHelpers
   def create_user(role)
     User.create(
@@ -31,17 +34,11 @@ module CategoryHelpers
     fill_in("Name", with: category_name)
     fill_in("Description", with: category_description)
     click_on "Submit"
-    should_be_on_categories_page(category_name, category_description)
-  end
-
-  def should_be_on_categories_page(category_name, category_description, action = "created")
-    expect(page).to have_text("Category was successfully #{action}.")
-    expect(page).to have_text("Categories > #{category_name}")
-    expect(page).to have_text(category_name)
-    expect(page).to have_text(category_description)
-    find_button "Edit"
-    find_button "Create Discussion"
-    expect(page).to have_text("DISCUSSION REPLIES LAST POST")
+    expect(page).to have_correct_category_name_on_page(category_name)
+    expect(page).to have_correct_category_description_on_page(category_description)
+    expect(page).to have_correct_message_for_action("created")
+    expect(page).to have_expected_buttons
+    expect(page).to have_the_expected_category_header("DISCUSSION REPLIES LAST POST")
   end
 
   def edit_category(updated_name = "New Title", updated_description = "New Description", category_id)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,11 +65,11 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   OmniAuth.config.test_mode = true
-  OmniAuth.config.mock_auth[:google_oauth0] = OmniAuth::AuthHash.new({
-    provider: "google_oauth0",
-    uid: "31413",
+  OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
+    provider: "google_oauth2",
+    uid: "31416",
     info: {
       name: "Test Person"
-    }
+    },
   })
 end

--- a/spec/system/category_spec.rb
+++ b/spec/system/category_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+require_relative "../modules/helpers"
+
+RSpec.describe "Category", type: :system do
+  include SessionHelpers
+  include CategoryHelpers
+
+  it "can be created" do
+    create_category("Test Category", "Test category description")
+  end
+
+  it "can be edited after creation" do
+    category_name = "Test Category"
+    category_description = "Test category description"
+    create_category(category_name, category_description)
+    category_id = Category.find_by(name: category_name, description: category_description).id
+    edit_category("Test Category 2", "Test category description 2", category_id)
+  end
+
+  it "can be deleted after creation" do
+    create_category("Test Category", "Test category description")
+
+    delete_category("Test Category", "Test category description")
+  end
+end

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -1,9 +1,19 @@
 require "rails_helper"
+require_relative "../modules/helpers"
 
-RSpec.describe "login", type: :system do
-  it "succesful" do
-    visit root_path
-    click_on "Login"
-    expect(page).to have_text("Logged in!")
+RSpec.describe "Session", type: :system do
+  include SessionHelpers
+
+  context "can be created via" do
+    it "login" do
+      login_as_user
+    end
+  end
+
+  context "can be destroyed via" do
+    it "logout" do
+      login_as_user
+      logout
+    end
   end
 end

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe "Session", type: :system do
 
   context "can be created via" do
     it "login" do
-      login_as_user
+      login_as("user")
     end
   end
 
   context "can be destroyed via" do
     it "logout" do
-      login_as_user
+      login_as("user")
       logout
     end
   end


### PR DESCRIPTION
### Category System Specs

This PR introduces basic Category system specs (create, update, & destroy specs).

Also included is some spec helper modules, `SessionHelpers` & `CategoryHelpers`, that are responsible for much of the heavy lifting for the actual clicks and navigation for each spec.

I also updated some views by adding element `id`s and added `logout` to `login_spec.rb`.
