### PR TITLE
Add RSpec specs to GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,5 @@ jobs:
         yarn --frozen-lockfile
     - name: Run Tests
       run: rails test
+    - name: Run Specs
+      run: bundle exec rspec


### PR DESCRIPTION
Simply add the RSpec specs to what the CI runs.